### PR TITLE
Allow the proxy protocol source address to be spoofed

### DIFF
--- a/address.go
+++ b/address.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+    "net"
+)
+
+type Addr struct {
+    IP net.IP
+}
+
+func (addr Addr) Network() string { return "tcp" }
+func (addr Addr) String() string { return addr.IP.String() }

--- a/mikoi.go
+++ b/mikoi.go
@@ -27,6 +27,7 @@ var opts struct {
 	Verbose bool `short:"V" long:"verbose" description:"verbose"`
 
 	ProxyProto bool `short:"P" long:"proxyproto" description:"use ProxyProto"`
+	ProxyProtoSrc string `long:"proxyproto-src" description:"Source address for ProxyProto"`
 }
 
 // When there is no argument for command line, mikoi is in proxy server mode.
@@ -132,7 +133,18 @@ func serve(conn net.Conn, errCh chan<- error) {
 
 	// Upgrade pconn to use ProxyProtocol
 	if opts.ProxyProto {
-		pconn = &ProxyConn{Conn: pconn}
+		var src net.Addr
+
+		if opts.ProxyProtoSrc != "" {
+			src = Addr{net.ParseIP(opts.ProxyProtoSrc)}
+		} else {
+			src, _, _ := net.SplitHostPort(pconn.LocalAddr().String())
+		}
+
+		pconn = &ProxyConn{
+			Conn: pconn,
+			Src: src,
+		}
 	}
 
 	// proxying a connection from plugin to server

--- a/proxy.go
+++ b/proxy.go
@@ -9,6 +9,7 @@ import (
 
 type ProxyConn struct {
 	net.Conn
+	Src net.Addr
 
 	once sync.Once
 }
@@ -33,7 +34,7 @@ func (c *ProxyConn) Write(b []byte) (int, error) {
 
 func (c *ProxyConn) writeProxyProtocolHeader() error {
 	s := c.Conn.LocalAddr()
-	saddr, sport, err := net.SplitHostPort(s.String())
+	_, sport, err := net.SplitHostPort(s.String())
 	if err != nil {
 		return err
 	}
@@ -58,6 +59,6 @@ func (c *ProxyConn) writeProxyProtocolHeader() error {
 		return errors.New("proxyconn: unknown length")
 	}
 
-	_, err = fmt.Fprintf(c.Conn, "PROXY %s %s %s %s %s\r\n", tcpStr, saddr, daddr, sport, dport)
+	_, err = fmt.Fprintf(c.Conn, "PROXY %s %s %s %s %s\r\n", tcpStr, c.Src, daddr, sport, dport)
 	return err
 }


### PR DESCRIPTION
Allow the proxy protocol source address to be spoofed with `--proxyproto-src`. This makes it easy to use `mikoi` for testing the behavior of applications which require the use of `PROXY` protocol.